### PR TITLE
[WIP] Micropython support

### DIFF
--- a/l293d/config.py
+++ b/l293d/config.py
@@ -13,7 +13,7 @@ class Config(object):
         Try and call get_`attr` on the cls.
         """
         try:
-            return cls.__dict__["get_" + attr].__func__(cls)
+            return getattr(cls, "get_" + attr)()
         except KeyError:
             raise AttributeError(
                 "object '{}' has no attribute '{}'".format(
@@ -28,7 +28,7 @@ class Config(object):
             # First try calling the set_ method. This will allow the set_
             # method to perform it's checks, then recursively call this method.
             try:
-                cls.__dict__["set_" + attr].__func__(cls, value)
+                getattr(cls, "set_" + attr)(value)
             except KeyError:
                 raise AttributeError(
                     "object '{}' has no attribute '{}'".format(

--- a/l293d/config.py
+++ b/l293d/config.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+class Config(object):
+    __verbose = True
+    __test_mode = False
+    __pin_numbering = 'BOARD'
+    pins_in_use = []
 
-class ConfigMeta(type):
-
+    @classmethod
     def __getattr__(cls, attr):
         """
         Try and call get_`attr` on the cls.
@@ -15,6 +19,7 @@ class ConfigMeta(type):
                 "object '{}' has no attribute '{}'".format(
                     cls.__name__, attr))
 
+    @classmethod
     def __setattr__(cls, attr, value):
         """
         Try and call set_`attr` on the cls.
@@ -32,26 +37,6 @@ class ConfigMeta(type):
             # Now that the set_ method has done it's checks, we can use super()
             # to actually set the value.
             super(ConfigMeta, cls).__setattr__(attr, value)
-
-
-def with_metaclass(mcls):
-    """
-    Allows compatibility for metaclass in python2 and python3
-    """
-    def decorator(cls):
-        body = vars(cls).copy()
-        body.pop("__dict__", None)
-        body.pop("__weakref__", None)
-        return mcls(cls.__name__, cls.__bases__, body)
-    return decorator
-
-
-@with_metaclass(ConfigMeta)
-class Config(object):
-    __verbose = True
-    __test_mode = False
-    __pin_numbering = 'BOARD'
-    pins_in_use = []
 
     @classmethod
     def set_verbose(cls, value):

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -8,6 +8,7 @@ from threading import Thread
 from time import sleep
 
 from l293d.config import Config
+Config = Config()
 
 
 def v_print(string):

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
 
-from collections import namedtuple
-from threading import Thread
+try:
+    from collections import namedtuple
+except ImportError:
+    from ucollections import namedtuple
+
+try:
+    from threading import Thread
+except ImportError:
+    threading = False
 from time import sleep
 
 from l293d.config import Config
@@ -102,6 +108,9 @@ class DC(object):
             self.pwm.start(speed.cycle)
         # If duration has been specified, sleep then stop
         if duration is not None and direction != 0:
+            if not threading:
+                self.stop(duration)
+                return
             stop_thread = Thread(target=self.stop, args=(duration,))
             # Sleep in thread
             stop_thread.start()
@@ -189,7 +198,7 @@ class Stepper(object):
                             'for more info')
 
 
-def pins_are_valid(pins, force_selection=False):
+def pins_are_valid(pins, force_selection=True):
     """
     Check the pins specified are valid for pin numbering in use
     """

--- a/l293d/gpio/__init__.py
+++ b/l293d/gpio/__init__.py
@@ -1,0 +1,20 @@
+from l293d.driver import v_print
+
+raspberry_pi, micropython = True, True
+
+try:
+    from RPi.GPIO import GPIO
+except ImportError:
+    raspberry_pi = False
+
+try:
+    from machine import Pin
+    from l293d.gpio.micropython import GPIO
+except ImportError:
+    micropython = False
+
+if not raspberry_pi and not micropython:
+    v_print(
+        "Can't import a GPIO controller; test mode has been enabled:\n"
+        "http://l293d.rtfd.io/en/latest/user-guide/configuration/#test-mode")
+    from l293d.gpio.testgpio import GPIO

--- a/l293d/gpio/micropython.py
+++ b/l293d/gpio/micropython.py
@@ -2,7 +2,7 @@
 from l293d.driver import v_print
 
 
-class MicroPythonGPIO(GPIOStub):
+class GPIO(object):
     __pins = {}
 
     IN = 0

--- a/l293d/gpio/micropython.py
+++ b/l293d/gpio/micropython.py
@@ -1,4 +1,6 @@
 
+import machine
+
 from l293d.driver import v_print
 
 
@@ -13,9 +15,9 @@ class GPIO(object):
     BOARD = "BOARD"
     BCM = "BCM"
 
-    class PWM(object):
-        def __init__(self, pin_num, freq):
-            self.pin = GPIO._GPIO__pins[pin_num]
+    class PwmObject(object):
+        def __init__(self, pin, freq):
+            self.pin = pin
             self.pwm = machine.PWM(self.pin)
             self.pwm.freq(freq)
 
@@ -23,7 +25,11 @@ class GPIO(object):
             self.pwm.duty(duty)
 
         def stop(self):
-            self.pwn.deinit()
+            self.pwm.deinit()
+
+    @classmethod
+    def PWM(cls, pin, freq):
+        return cls.PwmObject(cls.__pins[pin], freq)
     
     @classmethod
     def setwarnings(cls, warn):

--- a/l293d/gpio/micropython.py
+++ b/l293d/gpio/micropython.py
@@ -1,0 +1,43 @@
+
+from l293d.driver import v_print
+
+
+class MicroPythonGPIO(GPIOStub):
+    __pins = {}
+
+    IN = 0
+    OUT = 1
+    LOW = 0
+    HIGH = 1
+
+    BOARD = "BOARD"
+    BCM = "BCM"
+
+    class PWM(object):
+        def __init__(self, pin_num, freq):
+            self.pin = GPIO._GPIO__pins[pin_num]
+            self.pwm = machine.PWM(self.pin)
+            self.pwm.freq(freq)
+
+        def start(self, duty):
+            self.pwm.duty(duty)
+
+        def stop(self):
+            self.pwn.deinit()
+    
+    @classmethod
+    def setwarnings(cls, warn):
+        pass
+
+    @classmethod
+    def setmode(cls, mode):
+        pass
+
+    @classmethod
+    def setup(cls, pin_num, mode):
+        cls.__pins[pin_num] = machine.Pin(pin_num, mode)
+
+    @classmethod
+    def output(cls, pin_num, mode):
+        cls.__pins[pin_num].value(mode)
+

--- a/l293d/gpio/testgpio.py
+++ b/l293d/gpio/testgpio.py
@@ -1,0 +1,41 @@
+
+from l293d.driver import v_print
+
+
+class GPIO(object):
+    __pins = {}
+
+    IN = 0
+    OUT = 1
+    LOW = 0
+    HIGH = 1
+
+    BOARD = "BOARD"
+    BCM = "BCM"
+
+    class PWM(object):
+        def __init__(self, pin_num, freq):
+            pass
+
+        def start(self, duty):
+            pass
+
+        def stop(self):
+            pass
+    
+    @classmethod
+    def setwarnings(cls, warn):
+        pass
+
+    @classmethod
+    def setmode(cls, mode):
+        pass
+
+    @classmethod
+    def setup(cls, pin_num, mode):
+        pass
+
+    @classmethod
+    def output(cls, pin_num, mode):
+        pass
+


### PR DESCRIPTION
hello :wave: !!

This adds support for using `l293d` with Micropython.

<img src="https://user-images.githubusercontent.com/13941027/44301360-152d6900-a30d-11e8-8863-b382cf61f7d1.gif" width="100%">

### Changes

- I've stripped back the `Config` class, as it was using some features that Micropython doesn't support (`__dict__`, `with_metaclass` hacks). Now an instance of `Config` is created on module load, and `__getattr__` and `__setattr__` are class methods.

- I've created a `gpio` submodule to handle loading in what to use for GPIO. This allowed me to make a wrapper for Micropythons `machine` that mirrors `RPi.GPIO`. I also added a `testgpio` that is used when nothing GPIO related can be imported (might be useful for #62).



### WIP
Currently a work in progress as there are some things I need to figure out:
- [ ] PWM works differently in Micropython, there doesn't seem to be a concept of 100% duty cycle (always on). The range is [0 - 1023](https://docs.micropython.org/en/latest/esp8266/esp8266/tutorial/pwm.html#pulse-width-modulation), but I need to do some experiments with `RPi.GPIO` to see what it supports.
- [ ] Documentation. I managed to scrape by with the current docs, and a [pin diagram](https://github.com/lvidarte/esp8266/wiki/MicroPython%3A-GPIO-Pins) for my board. I don't know how good this can be though. I currently have an esp8266, but that's not the [only supported board](https://github.com/micropython/micropython/wiki/Boards-Summary).

