### PR TITLE
Add force_selection parameter to DC class

### DIFF
--- a/docs/user-guide/python-scripts.md
+++ b/docs/user-guide/python-scripts.md
@@ -16,6 +16,14 @@ In this example, the GPIO pin numbers will be the same as listed in [Hardware Se
 motor1 = l293d.DC(22, 18, 16)
 ```
 
+In some cases, it may be necessary to use some pins that aren't considered valid, but we can force it 
+by expliciting the `force_selection` parameter as `True` in DC class initialization (by default, this
+parameter is `False`).
+
+```python
+motor1 = l293d.DC(19, 21, 23, force_selection=True)
+```
+
 In this case, 'motor1' is what we're calling the DC motor object. You can call it whatever you want,
 for example `wheel_motor`, `london_eye` or `spinny_thing`.
 

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -58,7 +58,6 @@ class DC(object):
         self.motor_pins[0] = pin_a
         self.motor_pins[1] = pin_b
         self.motor_pins[2] = pin_c
-        self.force_selection = force_selection
 
         self.pwm = None
 
@@ -67,7 +66,7 @@ class DC(object):
         self.reversed = False
 
         # Check pins are valid
-        if pins_are_valid(self.motor_pins, self.force_selection):
+        if pins_are_valid(self.motor_pins, force_selection):
             self.exists = True
         # Append to global list of pins in use
         for pin in self.motor_pins:

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -52,12 +52,13 @@ class DC(object):
     motor_pins[2] is pinC is L293D pin7 or pin15 : Clockwise positive
     """
 
-    def __init__(self, pin_a=0, pin_b=0, pin_c=0):
+    def __init__(self, pin_a=0, pin_b=0, pin_c=0, force_selection=False):
         # Assign parameters to list
         self.motor_pins = [0 for x in range(3)]
         self.motor_pins[0] = pin_a
         self.motor_pins[1] = pin_b
         self.motor_pins[2] = pin_c
+        self.force_selection = force_selection
 
         self.pwm = None
 
@@ -66,7 +67,7 @@ class DC(object):
         self.reversed = False
 
         # Check pins are valid
-        if pins_are_valid(self.motor_pins):
+        if pins_are_valid(self.motor_pins, self.force_selection):
             self.exists = True
         # Append to global list of pins in use
         for pin in self.motor_pins:

--- a/tests/test_l293d.py
+++ b/tests/test_l293d.py
@@ -29,11 +29,10 @@ class L293DTestCase(unittest.TestCase):
         force_selection parameter
         """
         import l293d as d
-        print(str(d))
-        cases = (((33, 36, 37), False), ((19, 21, 23), True))
+        cases = (([33, 36, 37], False), ([19, 21, 23], True))
         for pins, force_selection in cases:
             motor = d.DC(*pins, force_selection=force_selection)
-            self.assertEqual(motor.force_selection, force_selection)
+            self.assertEqual(d.pins_in_use, pins)
             motor.remove()
         reload(d.driver)
 

--- a/tests/test_l293d.py
+++ b/tests/test_l293d.py
@@ -23,6 +23,20 @@ class L293DTestCase(unittest.TestCase):
         self.assertTrue(True)
         reload(d.driver)  # Revert changes
 
+    def test_create_motor_with_force_selection(self):
+        """
+        Test DC class instance creation with explicity
+        force_selection parameter
+        """
+        import l293d as d
+        print(str(d))
+        cases = (((33, 36, 37), False), ((19, 21, 23), True))
+        for pins, force_selection in cases:
+            motor = d.DC(*pins, force_selection=force_selection)
+            self.assertEqual(motor.force_selection, force_selection)
+            motor.remove()
+        reload(d.driver)
+
     def test_pins_string_list(self):
         """
         Test that the list of pins is returned correctly


### PR DESCRIPTION
Add a way to create CD classes intances forcing pin selection and avoid the error `GPIO pin number must be from list of valid pins: 19, 21, 23 To use selected pins anyway, set force_selection=True in function call.`

Exemple:
```python
motor = l293d.DC(16, 18, 22, force_selection=True)
```